### PR TITLE
Remove prefix from urlconf

### DIFF
--- a/docs_italia_convertitore_web/urls.py
+++ b/docs_italia_convertitore_web/urls.py
@@ -7,6 +7,6 @@ from .views import FileUploadView
 
 app_name = 'docs_italia_convertitore_web'
 urlpatterns = [
-    url(r'converter/$', FileUploadView.as_view(), name='docs-italia-converter-view'),
-    url(r'converter/message$', TemplateView.as_view(template_name="docs_italia_convertitore_web/conversion_started_message.html"), name="conversion-started"),
+    url(r'^$', FileUploadView.as_view(), name='docs-italia-converter-view'),
+    url(r'message$', TemplateView.as_view(template_name="docs_italia_convertitore_web/conversion_started_message.html"), name="conversion-started"),
 ]


### PR DESCRIPTION
It's better if we keep the prefix off this application, to allow any project using this use their preferred
URL convention