### PR TITLE
Fix the bug that prevented the celery task to work

### DIFF
--- a/docs_italia_convertitore_web/tasks.py
+++ b/docs_italia_convertitore_web/tasks.py
@@ -1,13 +1,10 @@
 """Basic tasks."""
 from __future__ import absolute_import
-import logging
 
-from base64 import urlsafe_b64encode
+import logging
 import os
 import subprocess
-import shutil
 
-from django.core.files.storage import default_storage
 from django.conf import settings
 from django.core.mail import send_mail
 
@@ -15,37 +12,34 @@ from readthedocs.worker import app
 
 log = logging.getLogger(__name__)
 
-CONVERSION_UPLOAD_DIR = os.path.join(settings.MEDIA_ROOT, 'tmp')
+PRODUCTION_DOMAIN = getattr(settings, 'PRODUCTION_DOMAIN')
+DOCS_ITALIA_CONVERSION_UPLOAD_PATH = os.path.join(settings.MEDIA_URL, 'tmp')
+DOCS_ITALIA_CONVERTER_EMAIL = getattr(settings, 'DOCS_ITALIA_CONVERTER_EMAIL', 'info@example.org')
 
 
 @app.task(queue='web')
-def process_file(email, uploaded):
+def process_file(email, saved, unique_key):
     """
     This celery task save the uploaded file from memory to the
     tmp folder and calls the `converti` command on it.
     Than emails the user with the link to download the converted file.
+    :param email: the user email
+    :param saved: The full path of the uploaded file
+    :parma unique_key: the unique name of the new folder
     """
-    unique_key = urlsafe_b64encode(email + uploaded.name).rstrip('=')# maybe we should use date time now to allow the upload of a file with the same name
-    new_folder_name = os.path.join(CONVERSION_UPLOAD_DIR, unique_key)
-    if not os.path.exists(new_folder_name):
-        os.mkdir(new_folder_name)
-    file_path = os.path.join(new_folder_name, uploaded.name)
-    saved = os.path.join(CONVERSION_UPLOAD_DIR, new_folder_name, uploaded.name)
-    with default_storage.open(saved, 'wb+') as destination:
-        for chunk in uploaded.chunks():
-            destination.write(chunk)
-    subprocess.call(['converti',  saved], cwd=new_folder_name)
-    zipped_name = os.path.splitext(uploaded.name)[0]
-    shutil.make_archive( #  create the archive
-        os.path.join(new_folder_name, zipped_name),
-        'zip',
-        os.path.join(new_folder_name,'risultato-conversione')
-    )
-    log.info('Processing uploaded file {} from {}'.format(uploaded.name, email))
+    file_path, file_name = os.path.split(saved)
+    new_file_name = os.path.splitext(os.path.basename(file_name))[0] + '.rst'
+    with open(os.path.join(file_path, new_file_name), 'w') as out:
+        subprocess.call(['pandoc', saved], stdout=out)
+    log.info('Processing uploaded file {} from {}'.format(saved, email))
     send_mail(
         'Conversione del documento effettuata',
-        'http://localhost:8000/media/tmp/{}/{}.zip'.format(unique_key, zipped_name),
-        'from@example.com',
+        'http://{}{}/{}/{}'.format(
+            PRODUCTION_DOMAIN, DOCS_ITALIA_CONVERSION_UPLOAD_PATH,
+            unique_key,
+            new_file_name
+        ),
+        DOCS_ITALIA_CONVERTER_EMAIL,
         [email],
         fail_silently=False,
     )

--- a/docs_italia_convertitore_web/tasks.py
+++ b/docs_italia_convertitore_web/tasks.py
@@ -5,10 +5,9 @@ import logging
 import os
 import subprocess
 
+from celery import shared_task
 from django.conf import settings
 from django.core.mail import send_mail
-
-from readthedocs.worker import app
 
 log = logging.getLogger(__name__)
 
@@ -17,33 +16,33 @@ DOCS_ITALIA_CONVERSION_UPLOAD_PATH = os.path.join(settings.MEDIA_URL, 'tmp')
 DOCS_ITALIA_CONVERTER_EMAIL = getattr(settings, 'DOCS_ITALIA_CONVERTER_EMAIL', 'info@example.org')
 
 
-@app.task(queue='web')
+@shared_task(queue='web')
 def process_file(email, saved, unique_key):
     """
     This celery task save the uploaded file from memory to the
     tmp folder and calls the `pandoc` command on it.
     Than emails the user with the link to download the converted file.
+
     :param email: the user email
     :param saved: the full path of the uploaded file
-    :parma unique_key: the unique name of the new folder
+    :param unique_key: the unique name of the new folder
     """
     file_path, file_name = os.path.split(saved)
     new_file_name = os.path.splitext(os.path.basename(file_name))[0] + '.rst'
-    err_log = os.path.splitext(os.path.basename(file_name))[0] + '_error.rst'
-    err_log_path = os.path.join(file_path, err_log)
     log.info('Processing uploaded file {} from {}'.format(saved, email))
-    with open(os.path.join(file_path, new_file_name), 'w') as out, open(err_log_path, 'w') as err:
-        subprocess.call(['pandoc', saved], stdout=out)
+    err_msg = None
+    out_msg = None
+    try:
+        out_msg = subprocess.check_output(['pandoc', saved], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        err_msg = e.output
     msg = 'http://{}{}/{}/{}'.format(
         PRODUCTION_DOMAIN, DOCS_ITALIA_CONVERSION_UPLOAD_PATH,
         unique_key,
         new_file_name
     )
-    if os.stat(err_log_path).st_size > 0:
-        with open(err_log_path) as el:
-            msg = el.read()
-        return_msg = msg
-        log.error('There was an error processing {}: {}'.format(saved, return_msg))
+    if err_msg:
+        log.error('There was an error processing %s: %s %s' % (saved, out_msg, err_msg))
     send_mail(
         'Conversione documento di DOCS ITALIA',
         msg,

--- a/docs_italia_convertitore_web/tasks.py
+++ b/docs_italia_convertitore_web/tasks.py
@@ -21,24 +21,32 @@ DOCS_ITALIA_CONVERTER_EMAIL = getattr(settings, 'DOCS_ITALIA_CONVERTER_EMAIL', '
 def process_file(email, saved, unique_key):
     """
     This celery task save the uploaded file from memory to the
-    tmp folder and calls the `converti` command on it.
+    tmp folder and calls the `pandoc` command on it.
     Than emails the user with the link to download the converted file.
     :param email: the user email
-    :param saved: The full path of the uploaded file
+    :param saved: the full path of the uploaded file
     :parma unique_key: the unique name of the new folder
     """
     file_path, file_name = os.path.split(saved)
     new_file_name = os.path.splitext(os.path.basename(file_name))[0] + '.rst'
-    with open(os.path.join(file_path, new_file_name), 'w') as out:
-        subprocess.call(['pandoc', saved], stdout=out)
+    err_log = os.path.splitext(os.path.basename(file_name))[0] + '_error.rst'
+    err_log_path = os.path.join(file_path, err_log)
     log.info('Processing uploaded file {} from {}'.format(saved, email))
+    with open(os.path.join(file_path, new_file_name), 'w') as out, open(err_log_path, 'w') as err:
+        subprocess.call(['pandoc', saved], stdout=out)
+    msg = 'http://{}{}/{}/{}'.format(
+        PRODUCTION_DOMAIN, DOCS_ITALIA_CONVERSION_UPLOAD_PATH,
+        unique_key,
+        new_file_name
+    )
+    if os.stat(err_log_path).st_size > 0:
+        with open(err_log_path) as el:
+            msg = el.read()
+        return_msg = msg
+        log.error('There was an error processing {}: {}'.format(saved, return_msg))
     send_mail(
-        'Conversione del documento effettuata',
-        'http://{}{}/{}/{}'.format(
-            PRODUCTION_DOMAIN, DOCS_ITALIA_CONVERSION_UPLOAD_PATH,
-            unique_key,
-            new_file_name
-        ),
+        'Conversione documento di DOCS ITALIA',
+        msg,
         DOCS_ITALIA_CONVERTER_EMAIL,
         [email],
         fail_silently=False,

--- a/docs_italia_convertitore_web/templates/docs_italia_convertitore_web/converter_index.html
+++ b/docs_italia_convertitore_web/templates/docs_italia_convertitore_web/converter_index.html
@@ -26,13 +26,14 @@
             <input name="file" type="file" multiple />
           </div>
         </div>
+        {% comment %}
         <div class="offset-md-4 col-md-4">
           <div class="form-group">
             <label for="monospace">Rileva testo monospace come codice</label>
             {{ form.monospace }}
           </div>
         </div>
-
+        {% endcomment %}
         <button form="converterForm" id="submit" type="submit" class="yo btn btn-primary" >
             Invia
         </button>

--- a/docs_italia_convertitore_web/views.py
+++ b/docs_italia_convertitore_web/views.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
 """Public project views."""
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
-from django.http import JsonResponse
+import os
+import uuid
+
+from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
+from django.http import JsonResponse
 from django.views.generic.edit import FormView
 
 from .forms import ItaliaConverterForm
 from .tasks import process_file
+
+CONVERSION_UPLOAD_DIR = os.path.join(settings.MEDIA_ROOT, 'tmp')
 
 
 class FileUploadView(FormView):
@@ -20,18 +25,27 @@ class FileUploadView(FormView):
     form_class = ItaliaConverterForm
 
     def form_valid(self, form):
-        """ the form valid function, calls the celery process task """
+        """
+        the form valid function save the file from memory to a
+        unique folder than calls the celery process task
+        """
         uploaded = form.cleaned_data['file']
         email = form.cleaned_data['email']
-        process_file.delay(email, uploaded)
+        unique_key = uuid.uuid1().hex
+        new_folder_name = os.path.join(CONVERSION_UPLOAD_DIR, unique_key)
+        os.mkdir(new_folder_name)
+        saved = os.path.join(CONVERSION_UPLOAD_DIR, new_folder_name, uploaded.name)
+        with default_storage.open(saved, 'wb+') as destination:
+            for chunk in uploaded.chunks():
+                destination.write(chunk)
+        process_file.delay(email, saved, unique_key)
         return super(FileUploadView, self).form_valid(form)
 
     def form_invalid(self, form):
         response = super(FileUploadView, self).form_invalid(form)
         if self.request.is_ajax():
             return JsonResponse(form.errors, status=400)
-        else:
-            return response
+        return response
 
     def get_success_url(self):
         return reverse('docs_italia_convertitore:conversion-started')

--- a/docs_italia_convertitore_web/views.py
+++ b/docs_italia_convertitore_web/views.py
@@ -33,7 +33,7 @@ class FileUploadView(FormView):
         email = form.cleaned_data['email']
         unique_key = uuid.uuid1().hex
         new_folder_name = os.path.join(CONVERSION_UPLOAD_DIR, unique_key)
-        os.mkdir(new_folder_name)
+        os.makedirs(new_folder_name)
         saved = os.path.join(CONVERSION_UPLOAD_DIR, new_folder_name, uploaded.name)
         with default_storage.open(saved, 'wb+') as destination:
             for chunk in uploaded.chunks():


### PR DESCRIPTION
There was a bug that prevented the celery task to work: by calling the delay function it failed because it tried to serialize an in memory file. Now the django valid form method saves the file from memory to the disk and creates a new folder and then calls the celery task which open a subprocess with the pandoc command and send the email with the download url to the user.