### PR TITLE
Fix errors in HTML email handling

### DIFF
--- a/docs_italia_convertitore_web/tasks.py
+++ b/docs_italia_convertitore_web/tasks.py
@@ -13,6 +13,7 @@ from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 from django.utils.http import urlquote
+from html2text import html2text
 
 from .utils import sentry_message
 
@@ -132,10 +133,12 @@ def process_file(email, uploaded_file, unique_key, use_converti=True, options_js
         template = 'docs_italia_convertitore_web/email/success_body.html'
         subject = 'Conversione documento di DOCS ITALIA'
     body = render_to_string(template, context=context)
+    body_text = html2text(body)
     send_mail(
         subject,
-        body,
+        body_text,
         DOCS_ITALIA_CONVERTER_EMAIL,
         [email],
         fail_silently=False,
+        html_message=body
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django>1.9,<1.10
 celery>=4.1,<4.2
+html2text

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -91,7 +91,9 @@ class TaskTest(TestCase):
         message = mail.outbox[0]
         new_file = os.path.splitext(os.path.basename(path))[0]
         self.assertEqual(message.subject, 'Conversione documento di DOCS ITALIA')
+        self.assertTrue(len(message.alternatives) == 1)
         self.assertIn('http://convert.com/media/tmp/super_unique/%s.zip' % new_file, message.body)
+        self.assertIn('http://convert.com/media/tmp/super_unique/%s.zip' % new_file, message.alternatives[0][0])
         self.assertIn('Conversion ID', message.body)
 
     @patch('docs_italia_convertitore_web.tasks.subprocess.check_output')


### PR DESCRIPTION
HTML message content was not wrapped in a multipart email

Text part is generated via html2text