### PR TITLE
Bump supported Django version to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,18 @@ matrix:
       env: TOX_ENV=pep8
     - python: 3.6
       env: TOX_ENV=isort
+    - python: 3.5
+      env: TOX_ENV=py35-django19
+    - python: 3.5
+      env: TOX_ENV=py35-django111
     - python: 3.6
-      env: TOX_ENV=py36
+      env: TOX_ENV=py36-django19
+    - python: 3.6
+      env: TOX_ENV=py36-django111
     - python: 3.7
-      env: TOX_ENV=py37
+      env: TOX_ENV=py37-django19
+    - python: 3.7
+      env: TOX_ENV=py37-django111
   fast_finish: true
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,9 @@ matrix:
     - python: 3.6
       env: TOX_ENV=isort
     - python: 3.6
-      env: TOX_ENV=py36-django-111
-    - python: 3.6
-      env: TOX_ENV=py36-django-19
-    - python: 3.5
-      env: TOX_ENV=py35-django-19
-    - python: 3.4
-      env: TOX_ENV=py34-django-19
+      env: TOX_ENV=py36
+    - python: 3.7
+      env: TOX_ENV=py37
   fast_finish: true
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,9 +6,9 @@ History
 0.4.0 (2019-10-03)
 ++++++++++++++++++
 
-* Bump supported Django version to 1.11
+* Add Django 1.11 support
 * Add Python 3.7 support
-* Drop Python 3.5 support
+* Drop Python 3.4 support
 * Prevent Premailer from hitting the network when running tests
 
 0.3.1 (2018-08-08)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 History
 -------
 
+0.4.0 (2019-10-03)
+++++++++++++++++++
+
+* Bump supported Django version to 1.11
+* Add Python 3.7 support
+* Drop Python 3.5 support
+* Prevent Premailer from hitting the network when running tests
+
 0.3.1 (2018-08-08)
 ++++++++++++++++++
 

--- a/docs_italia_convertitore_web/tasks.py
+++ b/docs_italia_convertitore_web/tasks.py
@@ -141,7 +141,11 @@ def process_file(email, uploaded_file, unique_key, use_converti=True, options_js
         template = 'docs_italia_convertitore_web/email/success_body.html'
         subject = 'Hai convertito un documento di Docs Italia'
     current_site = 'http://' + Site.objects.get_current().domain
-    body = transform(render_to_string(template, context=context), base_url=current_site)
+    body = transform(
+        render_to_string(template, context=context),
+        base_url=current_site,
+        allow_network=getattr(settings, 'PREMAILER_ALLOW_NETWORK', True),
+    )
     body_text = html2text(body)
     send_mail(
         subject,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django~=1.11
+Django>=1.9.0,!=1.10.*,<2.0
 celery>=4.1,<4.2
 html2text
 premailer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>1.9,<1.10
+django~=1.11
 celery>=4.1,<4.2
 html2text
 premailer

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
-import django
-
 DEBUG = True
 USE_TZ = True
 
@@ -27,24 +25,19 @@ INSTALLED_APPS = [
     "tests.test_app",
 ]
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
-    'django.middleware.common.CommonMiddleware',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
 
 SITE_ID = 1
-
-if django.VERSION >= (1, 10):
-    MIDDLEWARE = ()
-else:
-    MIDDLEWARE_CLASSES = ()
 
 PRODUCTION_DOMAIN = 'http://convert.com'
 MEDIA_URL = 'http://convert.com/media/'
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 CELERY_ALWAYS_EAGER = True
 BROKER_BACKEND = 'memory'
+
+PREMAILER_ALLOW_NETWORK = False

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -16,7 +16,9 @@ class ViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            '<input class="form-control" data-msg="Email non valida" id="id_email" name="email" type="email" />'
+            '<'
+            'input type="email" name="email" class="form-control" data-msg="Email non valida" required id="id_email" '
+            '/>',
         )
 
     def test_initial(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -14,12 +14,8 @@ class ViewsTest(TestCase):
     def test_no_initial(self):
         response = self.client.get(reverse('docs_italia_convertitore_web:docs-italia-converter-view'))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(
-            response,
-            '<'
-            'input type="email" name="email" class="form-control" data-msg="Email non valida" required id="id_email" '
-            '/>',
-        )
+        regex = r'<input.*data-msg="Email non valida".*/>'
+        self.assertRegex(response.content.decode('utf-8'), regex)
 
     def test_initial(self):
         user = User.objects.create_user(username='testuser', email='testuser@example.com', password='test')

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,24 @@
 [tox]
 envlist =
-    {py34,py35,py36}-django-{19,111},pep8,isort
+    py36,py37,pep8,isort
 skip_missing_interpreters = true
 
 [testenv]
-basepython =
-    py36: python3.6
-    py35: python3.5
 commands = coverage run --source docs_italia_convertitore_web runtests.py
 deps =
-    django-19: Django>=1.9,<1.10
-    django-111: Django>=1.11,<1.12
     -r{toxinidir}/requirements_test.txt
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/docs_italia_convertitore_web
 
 [testenv:pep8]
-basepython = python3
+basepython = python3.6
 commands =
     flake8
 deps = flake8
 skip_install = true
 
 [testenv:isort]
-basepython = python3
+basepython = python3.6
 commands =
     isort -c -rc -df
 deps = isort>=4.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 envlist =
-    py36,py37,pep8,isort
+    py{35,36,37}-django{19,111},pep8,isort
 skip_missing_interpreters = true
 
 [testenv]
 commands = coverage run --source docs_italia_convertitore_web runtests.py
 deps =
+    django19: Django~=1.9.0
+    django111: Django~=1.11.0
     -r{toxinidir}/requirements_test.txt
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/docs_italia_convertitore_web


### PR DESCRIPTION
Bump supported Django version to 1.11
Add Python 3.7 support
Drop Python 3.5 support
Prevent Premailer from hitting the network when running tests

Fixes #41 