### PR TITLE
Fix #43: "undefined" unit of measure

### DIFF
--- a/docs_italia_convertitore_web/static/js/docs_italia_convertitore.js
+++ b/docs_italia_convertitore_web/static/js/docs_italia_convertitore.js
@@ -50,8 +50,7 @@ $(document).ready(function() {
         dictUploadCanceled: "Caricamento annullato",
         dictCancelUploadConfirmation: "Vuoi davvero interrompere il caricamento?",
         dictRemoveFile: "Rimuovi",
-        dictMaxFilesExceeded: "Non puoi caricare altri file",
-        dictFileSizeUnits: "Non puoi superare il numero di file consentito per quest'area"
+        dictMaxFilesExceeded: "Non puoi caricare altri file"
     })
 
     $('.it-info').on('click', function () {


### PR DESCRIPTION
Fix #43 

L'oggetto contenente i valori per le unità di misura veniva sovrascritto erroneamente da una stringa.
